### PR TITLE
Revert "REThreaded: convert gen- and delete-Textures to no-ops"

### DIFF
--- a/libs/renderengine/threaded/RenderEngineThreaded.cpp
+++ b/libs/renderengine/threaded/RenderEngineThreaded.cpp
@@ -178,10 +178,6 @@ void RenderEngineThreaded::dump(std::string& result) {
 
 void RenderEngineThreaded::genTextures(size_t count, uint32_t* names) {
     ATRACE_CALL();
-    // This is a no-op in SkiaRenderEngine.
-    if (getRenderEngineType() != RenderEngineType::THREADED) {
-        return;
-    }
     std::promise<void> resultPromise;
     std::future<void> resultFuture = resultPromise.get_future();
     {
@@ -198,10 +194,6 @@ void RenderEngineThreaded::genTextures(size_t count, uint32_t* names) {
 
 void RenderEngineThreaded::deleteTextures(size_t count, uint32_t const* names) {
     ATRACE_CALL();
-    // This is a no-op in SkiaRenderEngine.
-    if (getRenderEngineType() != RenderEngineType::THREADED) {
-        return;
-    }
     std::promise<void> resultPromise;
     std::future<void> resultFuture = resultPromise.get_future();
     {


### PR DESCRIPTION
This reverts commit 48b5f3cbeae031324406ccbcb037651c66611adb.

Reason for revert: This is causing laggy bootanimation for some devices

Test: boot, see no more bootanimation lags
Change-Id: I05fc60a6ffa874e393f19a1fedb51bb054b2da0c